### PR TITLE
Fix code scanning alert no. 91: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -15,12 +15,16 @@ const logger = require('../lib/logger')
 module.exports = function profileImageUrlUpload () {
   return (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
-      const url = req.body.imageUrl
-      if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
+      const url = new URL(req.body.imageUrl)
+      const allowedHostnames = ['example.com', 'another-example.com']
+      if (!allowedHostnames.includes(url.hostname)) {
+        return next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
+      }
+      if (url.pathname.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {
         const imageRequest = request
-          .get(url)
+          .get(url.href)
           .on('error', function (err: unknown) {
             UserModel.findByPk(loggedInUser.data.id).then(async (user: UserModel | null) => { return await user?.update({ profileImage: url }) }).catch((error: Error) => { next(error) })
             logger.warn(`Error retrieving user profile image: ${utils.getErrorMessage(err)}; using image link directly`)


### PR DESCRIPTION
Fixes [https://github.com/dhanachavan/juice-shop/security/code-scanning/91](https://github.com/dhanachavan/juice-shop/security/code-scanning/91)

To fix the SSRF vulnerability, we need to ensure that the user-provided URL is validated against a whitelist of allowed domains or subdomains. This can be achieved by extracting the hostname from the user-provided URL and checking it against a predefined list of allowed hostnames. If the hostname is not in the allowed list, the request should be blocked.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
