### PR TITLE
Fix code scanning alert no. 288: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -31,7 +31,7 @@ module.exports = function productReviews () {
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find({ product: { $eq: id } }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Fixes [https://github.com/dhanachavan/juice-shop/security/code-scanning/288](https://github.com/dhanachavan/juice-shop/security/code-scanning/288)

To fix the problem, we need to ensure that user input is properly sanitized before being used in the MongoDB query. Instead of using the `$where` operator with a string concatenation, we should use parameterized queries or other MongoDB operators that do not involve executing JavaScript code.

The best way to fix this issue is to use the `$eq` operator to compare the `product` field with the `id` parameter. This avoids the need to use the `$where` operator and prevents the possibility of code injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
